### PR TITLE
feat: Add clarification request detection with configurable patterns

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -103,12 +103,21 @@ const (
 // AGENT CONFIGURATION
 // ============================================================================
 
+// ClarificationDetection configures how the agent handles LLM clarification requests.
+// When enabled, the agent detects when an LLM asks for confirmation instead of acting.
+type ClarificationDetection struct {
+	Enabled            bool     `yaml:"enabled"`                       // Enable clarification detection (default: false)
+	Level              string   `yaml:"level,omitempty"`               // Log level: "info", "warning", "error" (default: "warning")
+	UseBuiltinPatterns *bool    `yaml:"use_builtin_patterns,omitempty"` // Use built-in heuristics (default: true)
+	CustomPatterns     []string `yaml:"custom_patterns,omitempty"`      // Additional regex patterns
+}
+
 type Agent struct {
-	Name         string        `yaml:"name"`
-	Settings     Settings      `yaml:"settings"`
-	Servers      []AgentServer `yaml:"servers"`
-	Provider     string        `yaml:"provider"`
-	SystemPrompt string        `yaml:"system_prompt,omitempty"`
+	Name                   string                 `yaml:"name"`
+	Settings               Settings               `yaml:"settings"`
+	Servers                []AgentServer          `yaml:"servers"`
+	Provider               string                 `yaml:"provider"`
+	ClarificationDetection ClarificationDetection `yaml:"clarification_detection,omitempty"`
 }
 
 type AgentServer struct {

--- a/test/agent_test.go
+++ b/test/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 	"testing"
 	"time"
 
@@ -702,4 +703,263 @@ func TestExecuteToolWithTimeout(t *testing.T) {
 	assert.NotEmpty(t, response)
 
 	mockClient.AssertExpectations(t)
+}
+
+func TestIsClarificationRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected bool
+	}{
+		// Positive cases - should detect clarification requests
+		{
+			name:     "would you like me to",
+			text:     "I found the file. Would you like me to read its contents?",
+			expected: true,
+		},
+		{
+			name:     "do you want me to",
+			text:     "Do you want me to create this file for you?",
+			expected: true,
+		},
+		{
+			name:     "should i proceed",
+			text:     "I'm ready to delete these files. Should I proceed?",
+			expected: true,
+		},
+		{
+			name:     "shall i proceed",
+			text:     "The operation is ready. Shall I proceed with the changes?",
+			expected: true,
+		},
+		{
+			name:     "shall i continue",
+			text:     "I've completed step 1. Shall I continue with step 2?",
+			expected: true,
+		},
+		{
+			name:     "would you prefer",
+			text:     "Would you prefer JSON or YAML format for the output?",
+			expected: true,
+		},
+		{
+			name:     "do you prefer",
+			text:     "Do you prefer to save this to a file or display it?",
+			expected: true,
+		},
+		{
+			name:     "please confirm",
+			text:     "I will delete all files in /tmp. Please confirm before I proceed.",
+			expected: true,
+		},
+		{
+			name:     "please clarify",
+			text:     "Please clarify which directory you want me to use.",
+			expected: true,
+		},
+		{
+			name:     "can you confirm",
+			text:     "Can you confirm that this is the correct file path?",
+			expected: true,
+		},
+		{
+			name:     "can you clarify",
+			text:     "Can you clarify what format you need?",
+			expected: true,
+		},
+		{
+			name:     "let me know if",
+			text:     "I've prepared the script. Let me know if you want me to run it.",
+			expected: true,
+		},
+		{
+			name:     "is that correct",
+			text:     "You want to rename the file to 'output.txt', is that correct?",
+			expected: true,
+		},
+		{
+			name:     "is this correct",
+			text:     "The target directory is /home/user. Is this correct?",
+			expected: true,
+		},
+		{
+			name:     "would you like to",
+			text:     "Would you like to see the full contents of the file?",
+			expected: true,
+		},
+		{
+			name:     "do you want to proceed",
+			text:     "Do you want to proceed with this operation?",
+			expected: true,
+		},
+		{
+			name:     "case insensitive - uppercase",
+			text:     "WOULD YOU LIKE ME TO help with that?",
+			expected: true,
+		},
+		{
+			name:     "case insensitive - mixed case",
+			text:     "Should I Proceed with the deletion?",
+			expected: true,
+		},
+		{
+			name:     "pattern in middle of text",
+			text:     "I analyzed the data and found 3 issues. Do you want me to fix them automatically or show you the details first?",
+			expected: true,
+		},
+		// Negative cases - should NOT be detected as clarification
+		{
+			name:     "direct action statement",
+			text:     "I have created the file successfully.",
+			expected: false,
+		},
+		{
+			name:     "information response",
+			text:     "The file contains 150 lines of code.",
+			expected: false,
+		},
+		{
+			name:     "task completion",
+			text:     "Done! I've updated the configuration file with the new settings.",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			text:     "",
+			expected: false,
+		},
+		{
+			name:     "unrelated question",
+			text:     "What is the current directory?",
+			expected: false,
+		},
+		{
+			name:     "statement with similar words",
+			text:     "I would like to note that the file was modified yesterday.",
+			expected: false,
+		},
+		{
+			name:     "past tense action",
+			text:     "I proceeded to create the file as requested.",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test with builtin patterns enabled (default behavior)
+			result := agent.IsClarificationRequest(tt.text, true, nil)
+			assert.Equal(t, tt.expected, result, "IsClarificationRequest(%q, true, nil) = %v, want %v", tt.text, result, tt.expected)
+		})
+	}
+}
+
+func TestIsClarificationRequest_CustomPatterns(t *testing.T) {
+	// Test custom regex patterns
+	customPattern := regexp.MustCompile(`(?i)¿te gustaría`)
+	germanPattern := regexp.MustCompile(`(?i)möchten sie`)
+
+	tests := []struct {
+		name               string
+		text               string
+		useBuiltin         bool
+		customPatterns     []*regexp.Regexp
+		expected           bool
+	}{
+		// Custom patterns only (builtin disabled)
+		{
+			name:           "custom pattern matches - Spanish",
+			text:           "¿Te gustaría que proceda con la operación?",
+			useBuiltin:     false,
+			customPatterns: []*regexp.Regexp{customPattern},
+			expected:       true,
+		},
+		{
+			name:           "custom pattern matches - German",
+			text:           "Möchten Sie fortfahren?",
+			useBuiltin:     false,
+			customPatterns: []*regexp.Regexp{germanPattern},
+			expected:       true,
+		},
+		{
+			name:           "custom pattern does not match",
+			text:           "I have completed the task.",
+			useBuiltin:     false,
+			customPatterns: []*regexp.Regexp{customPattern},
+			expected:       false,
+		},
+		{
+			name:           "builtin disabled - builtin pattern should not match",
+			text:           "Would you like me to proceed?",
+			useBuiltin:     false,
+			customPatterns: []*regexp.Regexp{customPattern},
+			expected:       false,
+		},
+		// Builtin + custom patterns (additive mode)
+		{
+			name:           "additive - builtin matches",
+			text:           "Would you like me to proceed?",
+			useBuiltin:     true,
+			customPatterns: []*regexp.Regexp{customPattern},
+			expected:       true,
+		},
+		{
+			name:           "additive - custom matches",
+			text:           "¿Te gustaría continuar?",
+			useBuiltin:     true,
+			customPatterns: []*regexp.Regexp{customPattern},
+			expected:       true,
+		},
+		{
+			name:           "additive - neither matches",
+			text:           "Task completed successfully.",
+			useBuiltin:     true,
+			customPatterns: []*regexp.Regexp{customPattern},
+			expected:       false,
+		},
+		// Multiple custom patterns
+		{
+			name:           "multiple custom - first matches",
+			text:           "¿Te gustaría proceder?",
+			useBuiltin:     false,
+			customPatterns: []*regexp.Regexp{customPattern, germanPattern},
+			expected:       true,
+		},
+		{
+			name:           "multiple custom - second matches",
+			text:           "Möchten Sie das bestätigen?",
+			useBuiltin:     false,
+			customPatterns: []*regexp.Regexp{customPattern, germanPattern},
+			expected:       true,
+		},
+		// Empty/nil patterns
+		{
+			name:           "nil custom patterns with builtin",
+			text:           "Would you like me to help?",
+			useBuiltin:     true,
+			customPatterns: nil,
+			expected:       true,
+		},
+		{
+			name:           "empty custom patterns with builtin",
+			text:           "Would you like me to help?",
+			useBuiltin:     true,
+			customPatterns: []*regexp.Regexp{},
+			expected:       true,
+		},
+		{
+			name:           "nil custom patterns without builtin",
+			text:           "Would you like me to help?",
+			useBuiltin:     false,
+			customPatterns: nil,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := agent.IsClarificationRequest(tt.text, tt.useBuiltin, tt.customPatterns)
+			assert.Equal(t, tt.expected, result, "IsClarificationRequest(%q, %v, patterns) = %v, want %v", tt.text, tt.useBuiltin, result, tt.expected)
+		})
+	}
 }

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -2585,6 +2585,106 @@ func TestInitProviders_EnvironmentVariableResolution(t *testing.T) {
 }
 
 // ============================================================================
+// Clarification Pattern Compilation Tests
+// ============================================================================
+
+func TestCompileClarificationPatterns(t *testing.T) {
+	logger.SetupLogger(NewDummyWriter(), true)
+
+	tests := []struct {
+		name           string
+		patterns       []string
+		expectedCount  int
+		description    string
+	}{
+		{
+			name:          "valid patterns",
+			patterns:      []string{"(?i)would you like", "(?i)should i proceed"},
+			expectedCount: 2,
+			description:   "All valid patterns should compile",
+		},
+		{
+			name:          "empty patterns list",
+			patterns:      []string{},
+			expectedCount: 0,
+			description:   "Empty list should return nil",
+		},
+		{
+			name:          "nil patterns",
+			patterns:      nil,
+			expectedCount: 0,
+			description:   "Nil should return nil",
+		},
+		{
+			name:          "invalid regex pattern",
+			patterns:      []string{"[invalid(regex"},
+			expectedCount: 0,
+			description:   "Invalid pattern should be skipped",
+		},
+		{
+			name:          "mix of valid and invalid patterns",
+			patterns:      []string{"(?i)valid pattern", "[invalid(", "(?i)another valid"},
+			expectedCount: 2,
+			description:   "Only valid patterns should be compiled",
+		},
+		{
+			name:          "multiple invalid patterns",
+			patterns:      []string{"[bad", "(unclosed", "*invalid"},
+			expectedCount: 0,
+			description:   "All invalid patterns should be skipped",
+		},
+		{
+			name:          "unicode patterns",
+			patterns:      []string{"(?i)¿te gustaría", "(?i)möchten sie"},
+			expectedCount: 2,
+			description:   "Unicode patterns should compile correctly",
+		},
+		{
+			name:          "complex regex patterns",
+			patterns:      []string{`^(would|should|shall)\s+(you|i)\s+`, `\b(confirm|clarify)\b`},
+			expectedCount: 2,
+			description:   "Complex regex patterns should compile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.CompileClarificationPatterns(tt.patterns)
+
+			if tt.expectedCount == 0 {
+				assert.True(t, result == nil || len(result) == 0,
+					"%s: expected nil or empty, got %d patterns", tt.description, len(result))
+			} else {
+				require.NotNil(t, result, "%s: expected non-nil result", tt.description)
+				assert.Equal(t, tt.expectedCount, len(result),
+					"%s: expected %d patterns, got %d", tt.description, tt.expectedCount, len(result))
+			}
+		})
+	}
+}
+
+func TestCompileClarificationPatterns_InvalidPatternsContinue(t *testing.T) {
+	logger.SetupLogger(NewDummyWriter(), true)
+
+	// Test that invalid patterns don't prevent valid ones from being compiled
+	patterns := []string{
+		"(?i)first valid",
+		"[invalid pattern",  // This should be skipped
+		"(?i)second valid",
+		"(unclosed group",   // This should be skipped
+		"(?i)third valid",
+	}
+
+	result := engine.CompileClarificationPatterns(patterns)
+	require.NotNil(t, result)
+	assert.Equal(t, 3, len(result), "Should have 3 valid compiled patterns")
+
+	// Verify the compiled patterns work correctly
+	testText := "First valid pattern here"
+	assert.True(t, result[0].MatchString(testText), "First pattern should match")
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Detect when LLMs ask for clarification instead of taking action. This helps identify when agents respond with questions like "Would you like me to..." instead of executing tasks autonomously.

Closes #8

## Features

- **Per-agent clarification detection** - Enable/disable per agent
- **Configurable log level** - `info`, `warning`, or `error`
- **16 builtin English detection patterns** - Common clarification phrases
- **Custom regex patterns support** - Additive by default
- **Option to disable builtin patterns** - For custom-only detection

## Configuration

```yaml
agents:
  - name: autonomous-agent
    provider: my-provider
    clarification_detection:
      enabled: true              # Enable detection (default: false)
      level: warning             # Log level (default: warning)
      use_builtin_patterns: true # Use builtin patterns (default: true)
      custom_patterns:           # Additional regex patterns
        - "(?i)¿te gustaría"     # Spanish
        - "(?i)möchten sie"      # German
    servers:
      - name: my-server
```

## Builtin Patterns (16)

- `would you like me to`
- `do you want me to`
- `should i proceed`
- `shall i proceed`
- `shall i continue`
- `would you prefer`
- `do you prefer`
- `please confirm`
- `please clarify`
- `can you confirm`
- `can you clarify`
- `let me know if`
- `is that correct`
- `is this correct`
- `would you like to`
- `do you want to proceed`

## Changes

| File | Changes |
|------|---------|
| `model/model.go` | Added `UseBuiltinPatterns` and `CustomPatterns` fields to `ClarificationDetection` |
| `agent/agent.go` | Updated `AgentConfig`, exported `BuiltinClarificationPatterns`, updated `IsClarificationRequest` |
| `engine/engine.go` | Added `CompileClarificationPatterns()`, pattern compilation at config load |
| `test/agent_test.go` | Added 39 unit tests for detection logic |
| `test/model_test.go` | Added 9 YAML parsing tests |
| `test/engine_test.go` | Added 9 pattern compilation tests |
| `README.md` | Updated documentation with examples |

## Testing

- **57 unit tests** covering all functionality
- Pattern compilation with invalid regex handling (logged & skipped)
- YAML configuration parsing tests
- Custom pattern detection tests (Spanish, German, etc.)
- Additive mode tests (builtin + custom)

## Motivation

During LLM testing, some models ask for confirmation before taking actions (e.g., "Would you like me to proceed...") instead of executing tasks directly. This caused tests to fail silently because the agent loop stopped when receiving text without tool calls.

This feature helps test authors:
1. Detect when agents are asking instead of acting
2. Log or fail tests based on severity
3. Support multilingual detection with custom patterns

## Tip: Combine with `system_prompt`

```yaml
agents:
  - name: autonomous-agent
    provider: my-provider
    system_prompt: |
      Execute tasks directly without asking for confirmation.
    clarification_detection:
      enabled: true
      level: error  # Treat clarification requests as errors
```